### PR TITLE
Address security of .zsh_history_ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,25 @@ Print the last 10 commands you ran in the current directory
 ## Usage
 
 1. Add this function to your `.zshrc`
+
 ```
 function zshaddhistory() {
 	echo "${1%%$'\n'}⋮${PWD}   " >> ~/.zsh_history_ext
 }
 ```
-2. Download or copy the `jog` script from this repo and place it somewhere in your `$PATH`. 
 
-3. Restart your current terminal sessions for changes to take effect. `exec $SHELL`
+2. Download or copy the `jog` script from this repo and place it somewhere in your `$PATH`.
 
-4. Use `jog` whenever you find yourself lost and confused.
+3. Run `touch ~/.zsh_history_ext ; chmod 600 ~/.zsh_history_ext` to ensure that only you can read and write your history.
+
+4. Restart your current terminal sessions for changes to take effect. `exec $SHELL`
+
+5. Use `jog` whenever you find yourself lost and confused.
 
 It's not possible to retroactively store the directory in which a command was run, so **this tool will only work from this point forward.**
 
 ## Todo List
+
 Contributions and feature requests are welcome
 
 - Add support for other shells: bash, fish.


### PR DESCRIPTION
Without this change, .zsh_history_ext is 664 by default, which
means anyone can read the user's command history.